### PR TITLE
feat: add support for pr draft state

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ notionSync({
   // based on the Pull Request lifecycle.
   prStatusMap: {
     open: "In progress",
+    draft: "In progress",
     closed: "Done",
     merged: "Done",
     locked: "Done",


### PR DESCRIPTION
Add support for pull-request in draft state in order to map draft PRs to different Notion tasks state.

i.e. 
PR in draft ---> [Notion] **In Progress**
PR in open (not draft) ---> [Notion] **In Review**